### PR TITLE
Remove duplicates for prek and daycare centers

### DIFF
--- a/sql/dohmh_daycare.sql
+++ b/sql/dohmh_daycare.sql
@@ -2,6 +2,27 @@
 --from (select geo::json->'status' as status from dohmh_daycare) w
 --group by w.status::text;
 
+-- Update inspection_date with None value to '01/01/2000' temporarily
+UPDATE dohmh_daycare
+SET inspection_date = (CASE WHEN UPPER(inspection_date) = 'NONE' THEN '01/01/2000'
+							ELSE inspection_date
+						END);
+						
+-- Delete duplicates, only keep the records for each unique Day Care ID with the latest inspectation date
+DELETE FROM dohmh_daycare
+WHERE ogc_fid NOT IN(
+WITH date AS(
+SELECT day_care_id, MAX(inspection_date::date) as latest_date
+FROM dohmh_daycare
+GROUP BY day_care_id
+)
+SELECT min(ogc_fid) as orc_fid
+FROM dohmh_daycare dc, date d
+WHERE dc.day_care_id = d.day_care_id
+AND dc.inspection_date::date = d.latest_date
+GROUP BY dc.day_care_id
+);
+
 ALTER TABLE dohmh_daycare
 	ADD hash text, 
 	ADD	facname text,
@@ -22,6 +43,9 @@ ALTER TABLE dohmh_daycare
 
 update dohmh_daycare as t
 SET hash =  md5(CAST((t.*)AS text)), 
+	inspection_date = (CASE WHEN inspection_date::text = '01/01/2000' THEN 'None'
+								ELSE inspection_date::text
+							END),
 	facname = (CASE
 				WHEN center_name LIKE '%SBCC%' THEN initcap(legal_name)
 				WHEN center_name LIKE '%SCHOOL BASED CHILD CARE%' THEN initcap(legal_name)

--- a/sql/dohmh_daycare_deduplicate.sql
+++ b/sql/dohmh_daycare_deduplicate.sql
@@ -1,0 +1,75 @@
+-- Use DOE or ACS as the primary source and drop duplicate (same bin with similar name) DOHMH record
+
+-- REMOVE daycare center duplicates from DOHMH based on acs_daycareheadstart
+WITH flag AS(
+    WITH match AS(
+        SELECT TRIM(
+            REPLACE(
+            REPLACE(
+            UPPER(a.program_name),'-',' '),'  ', '')
+            ) AS acs_name, 
+            TRIM(
+            REPLACE(
+            REPLACE(
+            REPLACE(
+            REPLACE(
+            REPLACE(
+            REPLACE(
+            REPLACE(
+            UPPER(d.legal_name),'INC', ''),'LLC', ''),',',''),'.',''),'-',' '),'THE',''),'  ', '')
+            ) AS dohmh_name, 
+            d.day_care_id
+        FROM acs_daycareheadstart a, dohmh_daycare d
+        WHERE a.geo_bin = d.geo_bin
+        AND a.geo_bin != ''
+                )
+    SELECT day_care_id, string_to_array(acs_name, ' ')&&string_to_array(dohmh_name, ' ') AS similarity_flag
+    FROM match
+    )
+DELETE FROM dohmh_daycare
+WHERE day_care_id IN(
+SELECT day_care_id 
+FROM flag
+WHERE similarity_flag = True
+);
+
+-- REMOVE PREK duplicates from DOHMH based on doe_universalprek
+WITH flag AS(
+    WITH match AS(
+        SELECT TRIM(
+            REPLACE(
+            REPLACE(
+            REPLACE(
+            REPLACE(
+            REPLACE(
+            REPLACE(
+            REPLACE(
+            REPLACE(
+            UPPER(a.name),'SCHOOL',' '),'INC',' '),'LLC',' '),'THE',' '),'-',' '),',',' '),'.',' '),'  ', '')
+            ) AS doe_name, 
+            TRIM(
+            REPLACE(
+            REPLACE(
+            REPLACE(
+            REPLACE(
+            REPLACE(
+            REPLACE(
+            REPLACE(
+            UPPER(d.legal_name),'INC', ''),'LLC', ''),',',''),'.',' '),'-',' '),'THE',''),'  ', '')
+            ) AS dohmh_name, 
+            d.day_care_id
+        FROM doe_universalprek a, dohmh_daycare d
+        WHERE a.geo_bin = d.geo_bin
+        AND a.geo_bin != ''
+                )
+    SELECT day_care_id,string_to_array(doe_name, ' ')&&string_to_array(dohmh_name, ' ') AS similarity_flag
+    FROM match
+    )
+DELETE FROM dohmh_daycare
+WHERE day_care_id IN(
+SELECT day_care_id 
+FROM flag
+WHERE similarity_flag = True
+);
+
+


### PR DESCRIPTION
- modifying the SQL and taking the latest record (most recent Inspection Date) for each unique Day
Care ID 
- Use DOE or ACS as the primary source and drop duplicate (same bin with similar name) DOHMH record