### PR TITLE
Update census tract format

### DIFF
--- a/etl/utils.py
+++ b/etl/utils.py
@@ -102,7 +102,7 @@ geo_flow = Flow(
                                 dict(target=dict(name = 'geo_council', type = 'string'),
                                                 operation=lambda row: row['results'].get('City Council District', '')
                                                 ),
-                                dict(target=dict(name = 'geo_censtract', type = 'number'),
+                                dict(target=dict(name = 'geo_censtract', type = 'string'),
                                                 operation=lambda row: row['results'].get('2010 Census Tract', '')
                                                 ),
                                 dict(target=dict(name = 'geo_grc', type = 'string'),

--- a/etl/utils.py
+++ b/etl/utils.py
@@ -103,9 +103,7 @@ geo_flow = Flow(
                                                 operation=lambda row: row['results'].get('City Council District', '')
                                                 ),
                                 dict(target=dict(name = 'geo_censtract', type = 'number'),
-                                                operation=lambda row: row['results'].get('2010 Census Tract', '') 
-                                                                if row['results'].get('2010 Census Tract', '') != '000000'
-                                                                else ''
+                                                operation=lambda row: row['results'].get('2010 Census Tract', '')
                                                 ),
                                 dict(target=dict(name = 'geo_grc', type = 'string'),
                                                 operation=lambda row: row['results'].get('Geosupport Return Code (GRC)', '')

--- a/etl/utils.py
+++ b/etl/utils.py
@@ -102,8 +102,10 @@ geo_flow = Flow(
                                 dict(target=dict(name = 'geo_council', type = 'string'),
                                                 operation=lambda row: row['results'].get('City Council District', '')
                                                 ),
-                                dict(target=dict(name = 'geo_censtract', type = 'string'),
-                                                operation=lambda row: row['results'].get('2010 Census Tract', '')
+                                dict(target=dict(name = 'geo_censtract', type = 'number'),
+                                                operation=lambda row: row['results'].get('2010 Census Tract', '') 
+                                                                if row['results'].get('2010 Census Tract', '') != '000000'
+                                                                else ''
                                                 ),
                                 dict(target=dict(name = 'geo_grc', type = 'string'),
                                                 operation=lambda row: row['results'].get('Geosupport Return Code (GRC)', '')

--- a/sql/load_and_combine.sql
+++ b/sql/load_and_combine.sql
@@ -49,3 +49,10 @@ CALL load_to_facilities('uscourts_courts');
 CALL load_to_facilities('usdot_airports');
 CALL load_to_facilities('usdot_ports');
 CALL load_to_facilities('usnps_parks');
+
+UPDATE facilities
+SET censtract = (CASE
+                    WHEN censtract <> '0' THEN censtract
+                    ELSE NULL
+                END)
+;

--- a/sql/load_to_facilities.sql
+++ b/sql/load_to_facilities.sql
@@ -71,10 +71,11 @@ BEGIN
 					    geo_commboard,
 					    geo_nta,
 					    geo_council,
-					    geo_censtract,
+					    geo_censtract::double precision::text,
 					    wkb_geometry
 						FROM %I
-						WHERE geo_grc <> 71::text or geo_grc2 <> 71::text; ', tbl);
+						WHERE geo_grc <> 71::text or geo_grc2 <> 71::text
+						; ', tbl);
 	EXCEPTION WHEN others THEN
 		execute format('INSERT INTO 
     				facilities(


### PR DESCRIPTION
- Match the format of the census tract value that was in the old file. 
- After being loaded into postgres, the `geo_censtract` will be in string format without preceding zeros. Records with `geo_censtract` value as '000000' will be filled with empty string.